### PR TITLE
Replace arrow functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:integration": "cross-env TZ=UTC vitest run --coverage --project integration",
     "test:watch": "cross-env TZ=UTC vitest",
     "test:debug": "cross-env TZ=UTC vitest --inspect --no-file-parallelism",
-    "test:lint": "eslint"
+    "test:lint": "eslint",
+    "test:lint:fix": "eslint --fix"
   },
   "author": "John Watson",
   "license": "MIT",

--- a/src/account/index.js
+++ b/src/account/index.js
@@ -1,4 +1,0 @@
-export { register } from './register.js'
-export { login } from './login.js'
-export { resetPassword, setNewPassword } from './reset-password.js'
-export { getUser } from './user-manager.js'

--- a/src/account/login.js
+++ b/src/account/login.js
@@ -1,8 +1,8 @@
 import bcrypt from 'bcrypt'
 import { getUser } from './user-manager.js'
-import { create } from '../token/index.js'
+import { create } from '../token/create.js'
 
-const login = async (email, password) => {
+export async function login (email, password) {
   const user = await getUser(email)
 
   if (user === null || !await bcrypt.compare(password, user.passwordHash)) {
@@ -13,5 +13,3 @@ const login = async (email, password) => {
     token: create(user),
   }
 }
-
-export { login }

--- a/src/account/register.js
+++ b/src/account/register.js
@@ -1,8 +1,8 @@
 import config from '../config/index.js'
-import { create } from '../token/index.js'
+import { create } from '../token/create.js'
 import { userExists, createUser, isMember } from './user-manager.js'
 
-const register = async (email, password) => {
+export async function register (email, password) {
   if (await userExists(email)) {
     return false
   }
@@ -17,5 +17,3 @@ const register = async (email, password) => {
     token: create(user),
   }
 }
-
-export { register }

--- a/src/account/reset-password.js
+++ b/src/account/reset-password.js
@@ -1,9 +1,9 @@
 import bcrypt from 'bcrypt'
 import crypto from 'node:crypto'
 import db from '../data/index.js'
-import { sendResetPassword } from '../notifications/index.js'
+import { sendResetPassword } from '../notifications/send-reset-password.js'
 
-const resetPassword = async (email) => {
+export async function resetPassword (email) {
   const user = await db.User.findOne({
     where: { email },
   })
@@ -24,7 +24,7 @@ const resetPassword = async (email) => {
   await sendResetPassword(email, resetToken, user.userId)
 }
 
-const setNewPassword = async (userId, password, token) => {
+export async function setNewPassword (userId, password, token) {
   const user = await db.User.findByPk(userId)
 
   if (user === null) {
@@ -41,5 +41,3 @@ const setNewPassword = async (userId, password, token) => {
   user.resetExpiresAt = null
   await user.save()
 }
-
-export { resetPassword, setNewPassword }

--- a/src/account/role-manager.js
+++ b/src/account/role-manager.js
@@ -1,15 +1,15 @@
 import db from '../data/index.js'
 
-const getRole = async (roleName) => {
+async function getRole (roleName) {
   return db.Role.findOne({ where: { name: roleName } })
 }
 
-const addUserToRole = async (userId, roleName) => {
+export async function addUserToRole (userId, roleName) {
   const role = await getRole(roleName)
   await db.UserRole.create({ userId, roleId: role.roleId })
 }
 
-const getUserRoles = async (userId) => {
+export async function getUserRoles (userId) {
   return db.UserRole.findAll({
     where: { userId },
     raw: true,
@@ -18,5 +18,3 @@ const getUserRoles = async (userId) => {
     include: [db.Role],
   })
 }
-
-export { addUserToRole, getUserRoles }

--- a/src/account/user-manager.js
+++ b/src/account/user-manager.js
@@ -2,16 +2,16 @@ import db from '../data/index.js'
 import bcrypt from 'bcrypt'
 import { addUserToRole, getUserRoles } from './role-manager.js'
 
-const userExists = async (email) => {
+export async function userExists (email) {
   return await getUser(email) !== null
 }
 
-const isMember = async (email) => {
+export async function isMember (email) {
   const memberEmail = await db.Email.findOne({ where: { address: email } })
   return memberEmail !== null
 }
 
-const getUser = async (email) => {
+export async function getUser (email) {
   const user = await db.User.findOne({
     where: { email },
     raw: true,
@@ -24,7 +24,7 @@ const getUser = async (email) => {
   return user
 }
 
-const createUser = async (email, password) => {
+export async function createUser (email, password) {
   const passwordHash = await bcrypt.hash(password, 10)
 
   const user = await db.User.create({
@@ -35,5 +35,3 @@ const createUser = async (email, password) => {
   await addUserToRole(user.userId, 'user')
   return getUser(email)
 }
-
-export { userExists, getUser, createUser, isMember }

--- a/src/cache/client.js
+++ b/src/cache/client.js
@@ -5,7 +5,7 @@ import { getKeyPrefix } from './get-key-prefix.js'
 
 let client
 
-const start = async () => {
+export async function start () {
   client = createClient({ socket: config.cache.socket, password: config.cache.password })
   client.on('error', (err) => console.log(`Redis error: ${err}`))
   client.on('reconnecting', () => console.log('Redis reconnecting...'))
@@ -13,29 +13,27 @@ const start = async () => {
   await client.connect()
 }
 
-const stop = async () => {
+export async function stop () {
   if (client.isOpen) {
     await client.quit()
   }
 }
 
-const getKeys = async (cache) => {
+export async function getKeys (cache) {
   const prefix = getKeyPrefix(cache)
   const keys = await client.keys(`${prefix}:*`)
   return keys.map((key) => key.replace(`${prefix}:`, ''))
 }
 
-const get = async (cache, key) => {
+export async function get (cache, key) {
   const fullKey = getFullKey(cache, key)
   const value = await client.get(fullKey)
   return value ? JSON.parse(value) : {}
 }
 
-const set = async (cache, key, value) => {
+export async function set (cache, key, value) {
   const fullKey = getFullKey(cache, key)
   const serializedValue = JSON.stringify(value)
   console.log(`Setting cache key ${fullKey} with expiry ${config.cache.ttl} as ${serializedValue}`)
   await client.set(fullKey, serializedValue, { EX: config.cache.ttl })
 }
-
-export { start, stop, getKeys, get, set }

--- a/src/cache/get-full-key.js
+++ b/src/cache/get-full-key.js
@@ -1,8 +1,6 @@
 import { getKeyPrefix } from './get-key-prefix.js'
 
-const getFullKey = (cache, key) => {
+export function getFullKey (cache, key) {
   const prefix = getKeyPrefix(cache)
   return `${prefix}:${key}`
 }
-
-export { getFullKey }

--- a/src/cache/get-key-prefix.js
+++ b/src/cache/get-key-prefix.js
@@ -1,7 +1,5 @@
 import config from '../config/index.js'
 
-const getKeyPrefix = (cache) => {
+export function getKeyPrefix (cache) {
   return `${config.cache.partition}:${cache}`
 }
-
-export { getKeyPrefix }

--- a/src/cache/index.js
+++ b/src/cache/index.js
@@ -1,1 +1,0 @@
-export { start, stop, getKeys, get, set } from './client.js'

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import 'log-timestamp'
-import { start as startCache, stop as stopCache } from './cache/index.js'
-import { start as startServer } from './server/index.js'
+import { start as startCache, stop as stopCache } from './cache/client.js'
+import { start as startServer } from './server/start.js'
 import { SIGINT, SIGTERM } from './constants/signals.js'
 
 process.on([SIGTERM, SIGINT], async () => {

--- a/src/levenshtein.js
+++ b/src/levenshtein.js
@@ -1,4 +1,4 @@
-const calculateDistance = (a, b) => {
+export function calculateDistance (a, b) {
   if (a.length === 0) { return b.length }
   if (b.length === 0) { return a.length }
 
@@ -31,5 +31,3 @@ const calculateDistance = (a, b) => {
 
   return matrix[b.length][a.length]
 }
-
-export { calculateDistance }

--- a/src/managers/create-manager.js
+++ b/src/managers/create-manager.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const createManager = async (manager) => {
+export async function createManager (manager) {
   const createdManager = await db.Manager.create(manager)
   for (const email of manager.emails) {
     if (email.length) {
@@ -9,5 +9,3 @@ const createManager = async (manager) => {
   }
   return createdManager
 }
-
-export { createManager }

--- a/src/managers/delete-manager.js
+++ b/src/managers/delete-manager.js
@@ -1,8 +1,6 @@
 import db from '../data/index.js'
 
-const deleteManager = async (managerId) => {
+export async function deleteManager (managerId) {
   await db.Email.destroy({ where: { managerId } })
   await db.Manager.destroy({ where: { managerId } })
 }
-
-export { deleteManager }

--- a/src/managers/edit-manager.js
+++ b/src/managers/edit-manager.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const editManager = async (manager) => {
+export async function editManager (manager) {
   const updatedManager = await db.Manager.upsert(manager)
   const currentEmails = await db.Email.findAll({ where: { managerId: manager.managerId } })
   for (const email of manager.emails) {
@@ -17,5 +17,3 @@ const editManager = async (manager) => {
   }
   return updatedManager
 }
-
-export { editManager }

--- a/src/managers/get-manager.js
+++ b/src/managers/get-manager.js
@@ -1,7 +1,5 @@
 import db from '../data/index.js'
 
-const getManager = async (managerId) => {
+export async function getManager (managerId) {
   return db.Manager.findOne({ where: { managerId }, include: [{ model: db.Email, as: 'emails' }] })
 }
-
-export { getManager }

--- a/src/managers/get-managers.js
+++ b/src/managers/get-managers.js
@@ -1,7 +1,5 @@
 import db from '../data/index.js'
 
-const getManagers = async () => {
+export async function getManagers () {
   return db.Manager.findAll({ order: ['name'] })
 }
-
-export { getManagers }

--- a/src/managers/get-team.js
+++ b/src/managers/get-team.js
@@ -4,7 +4,7 @@ import { mapPlayer } from './map-player.js'
 import { orderKeepers } from '../utils/order-keepers.js'
 import { orderPlayers } from '../utils/order-players.js'
 
-const getTeam = async (managerId) => {
+export async function getTeam (managerId) {
   const manager = await db.Manager.findOne({
     where: { managerId },
     include: [
@@ -37,5 +37,3 @@ const getTeam = async (managerId) => {
     players: orderPlayers(manager.players.map(mapPlayer)),
   }
 }
-
-export { getTeam }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -1,6 +1,0 @@
-export { getManagers } from './get-managers.js'
-export { getManager } from './get-manager.js'
-export { createManager } from './create-manager.js'
-export { editManager } from './edit-manager.js'
-export { deleteManager } from './delete-manager.js'
-export { getTeam } from './get-team.js'

--- a/src/managers/map-keeper.js
+++ b/src/managers/map-keeper.js
@@ -8,4 +8,3 @@ export function mapKeeper (keeper) {
     cupConceded: keeper.conceded?.filter(x => x.cup).length ?? 0,
   }
 }
-

--- a/src/managers/map-keeper.js
+++ b/src/managers/map-keeper.js
@@ -1,4 +1,4 @@
-const mapKeeper = (keeper) => {
+export function mapKeeper (keeper) {
   return {
     playerId: keeper.teamId,
     teamId: keeper.teamId,
@@ -9,4 +9,3 @@ const mapKeeper = (keeper) => {
   }
 }
 
-export { mapKeeper }

--- a/src/managers/map-player.js
+++ b/src/managers/map-player.js
@@ -11,4 +11,3 @@ export function mapPlayer (player) {
     cupGoals: player.goals?.filter(x => x.cup).length ?? 0,
   }
 }
-

--- a/src/managers/map-player.js
+++ b/src/managers/map-player.js
@@ -1,4 +1,4 @@
-const mapPlayer = (player) => {
+export function mapPlayer (player) {
   return {
     playerId: player.dataValues.playerId,
     fullName: player.fullName,
@@ -12,4 +12,3 @@ const mapPlayer = (player) => {
   }
 }
 
-export { mapPlayer }

--- a/src/notifications/get-html-string.js
+++ b/src/notifications/get-html-string.js
@@ -1,8 +1,6 @@
 import nunjucks from 'nunjucks'
 
-const getHtmlStringFromFile = (file, context) => {
+export function getHtmlStringFromFile (file, context) {
   nunjucks.configure('src/notifications/views', { autoescape: true })
   return nunjucks.render(file, context)
 }
-
-export { getHtmlStringFromFile }

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -1,2 +1,0 @@
-export { sendResults } from './send-results.js'
-export { sendResetPassword } from './send-reset-password.js'

--- a/src/notifications/send-email.js
+++ b/src/notifications/send-email.js
@@ -13,4 +13,3 @@ export async function sendEmail (recipients, subject, body) {
     })
   }
 }
-

--- a/src/notifications/send-email.js
+++ b/src/notifications/send-email.js
@@ -1,7 +1,7 @@
 import nodemailer from 'nodemailer'
 import config from '../config/index.js'
 
-const sendEmail = async (recipients, subject, body) => {
+export async function sendEmail (recipients, subject, body) {
   if (config.smtp.host) {
     const transporter = nodemailer.createTransport(config.smtp)
 
@@ -14,4 +14,3 @@ const sendEmail = async (recipients, subject, body) => {
   }
 }
 
-export { sendEmail }

--- a/src/notifications/send-reset-password.js
+++ b/src/notifications/send-reset-password.js
@@ -2,10 +2,8 @@ import config from '../config/index.js'
 import { getHtmlStringFromFile } from './get-html-string.js'
 import { sendEmail } from './send-email.js'
 
-const sendResetPassword = async (email, token, userId) => {
+export async function sendResetPassword (email, token, userId) {
   const link = `${config.webUrl}/reset-password?token=${token}&userId=${userId}`
   const body = getHtmlStringFromFile('reset-password.html', { link })
   await sendEmail(email, 'Dream League - Reset Password', body)
 }
-
-export { sendResetPassword }

--- a/src/notifications/send-results.js
+++ b/src/notifications/send-results.js
@@ -1,9 +1,9 @@
 import db from '../data/index.js'
-import { getSummary } from '../results/index.js'
+import { getSummary } from '../results/get-summary.js'
 import { getHtmlStringFromFile } from './get-html-string.js'
 import { sendEmail } from './send-email.js'
 
-const sendResults = async (gameweekId) => {
+export async function sendResults (gameweekId) {
   const summary = await getSummary(gameweekId)
   const emails = await db.Email.findAll({ raw: true, attributes: ['address'] })
   if (emails.length) {
@@ -12,5 +12,3 @@ const sendResults = async (gameweekId) => {
     await sendEmail(addresses, `Dream League Results - Game Week ${gameweekId}`, body)
   }
 }
-
-export { sendResults }

--- a/src/refresh/index.js
+++ b/src/refresh/index.js
@@ -1,2 +1,0 @@
-export { refresh as refreshPlayers } from './players/index.js'
-export { refresh as refreshTeamsheet } from './teamsheet/index.js'

--- a/src/refresh/map-position.js
+++ b/src/refresh/map-position.js
@@ -15,4 +15,3 @@ export function mapPosition (position) {
       return undefined
   }
 }
-

--- a/src/refresh/map-position.js
+++ b/src/refresh/map-position.js
@@ -1,7 +1,7 @@
 import { GK, DEF, MID, FWD } from '../constants/position-codes.js'
 import { GOALKEEPER, DEFENDER, MIDFIELDER, FORWARD } from '../constants/positions.js'
 
-const mapPosition = (position) => {
+export function mapPosition (position) {
   switch (position) {
     case GK:
       return GOALKEEPER
@@ -16,4 +16,3 @@ const mapPosition = (position) => {
   }
 }
 
-export { mapPosition }

--- a/src/refresh/players/map-player.js
+++ b/src/refresh/players/map-player.js
@@ -2,7 +2,7 @@ import db from '../../data/index.js'
 import { mapPosition } from '../map-position.js'
 const positions = ['GK', 'DEF', 'MID', 'FWD']
 
-const mapPlayer = async (player) => {
+export async function mapPlayer (player) {
   const team = await db.Team.findOne({ attributes: ['teamId'], where: { alias: { [db.Sequelize.Op.iLike]: player.team } }, raw: true })
   const position = mapPosition(player.position)
   if (team && position) {
@@ -18,18 +18,16 @@ const mapPlayer = async (player) => {
   return undefined
 }
 
-const mapFirstName = (player) => {
+function mapFirstName (player) {
   if (!player.firstName || positions.includes(player.lastName) || !player.lastName) {
     return undefined
   }
   return player.firstName
 }
 
-const mapLastName = (player) => {
+function mapLastName (player) {
   if (player.firstName && (!player.lastName || positions.includes(player.lastName))) {
     return player.firstName
   }
   return player.lastName
 }
-
-export { mapPlayer }

--- a/src/refresh/players/refresh-players.js
+++ b/src/refresh/players/refresh-players.js
@@ -1,7 +1,7 @@
 import { mapPlayer } from './map-player.js'
 import { run } from './run.js'
 
-const refresh = async (players) => {
+export async function refreshPlayers (players) {
   const mappedPlayers = []
   const unmappedPlayers = []
   for (const player of players) {
@@ -22,5 +22,3 @@ const refresh = async (players) => {
     unmappedPlayers,
   }
 }
-
-export { refresh }

--- a/src/refresh/players/run.js
+++ b/src/refresh/players/run.js
@@ -1,8 +1,6 @@
 import db from '../../data/index.js'
 
-const run = async (players) => {
+export async function run (players) {
   await db.Player.truncate()
   await db.Player.bulkCreate(players)
 }
-
-export { run }

--- a/src/refresh/teamsheet/add-team.js
+++ b/src/refresh/teamsheet/add-team.js
@@ -1,6 +1,6 @@
 import db from '../../data/index.js'
 
-const addTeamsheetMatch = async (managerId, player, position, bestMatchId, distance) => {
+export async function addTeamsheetMatch (managerId, player, position, bestMatchId, distance) {
   await db.Teamsheet.create({
     managerId,
     player: player.player,
@@ -11,7 +11,7 @@ const addTeamsheetMatch = async (managerId, player, position, bestMatchId, dista
   })
 }
 
-const addPlayer = async (managerId, playerId, substitute) => {
+export async function addPlayer (managerId, playerId, substitute) {
   return db.ManagerPlayer.create({
     managerId,
     playerId,
@@ -19,12 +19,10 @@ const addPlayer = async (managerId, playerId, substitute) => {
   })
 }
 
-const addKeeper = async (managerId, teamId, substitute) => {
+export async function addKeeper (managerId, teamId, substitute) {
   return db.ManagerKeeper.create({
     managerId,
     teamId,
     substitute,
   })
 }
-
-export { addTeamsheetMatch, addPlayer, addKeeper }

--- a/src/refresh/teamsheet/get-league-data.js
+++ b/src/refresh/teamsheet/get-league-data.js
@@ -1,15 +1,13 @@
 import db from '../../data/index.js'
 
-const getManager = async (manager) => {
+export async function getManager (manager) {
   return db.Manager.findOne({ attributes: ['managerId'], where: { alias: { [db.Sequelize.Op.iLike]: manager } }, raw: true })
 }
 
-const getLeaguePlayers = async () => {
+export async function getLeaguePlayers () {
   return db.Player.findAll({ include: [{ model: db.Team, as: 'team', attributes: ['alias'] }], raw: true, nest: true })
 }
 
-const getLeagueTeams = async () => {
+export async function getLeagueTeams () {
   return db.Team.findAll({ raw: true })
 }
-
-export { getManager, getLeaguePlayers, getLeagueTeams }

--- a/src/refresh/teamsheet/map-player.js
+++ b/src/refresh/teamsheet/map-player.js
@@ -1,6 +1,6 @@
 import { calculateDistance } from '../../levenshtein.js'
 
-const mapPlayer = (players, matchPlayer, position) => {
+export function mapPlayer (players, matchPlayer, position) {
   const matchText = matchPlayer.replace(/\s/g, '').toUpperCase()
   let bestDistance = -1
   let bestPlayerId = -1
@@ -26,5 +26,3 @@ const mapPlayer = (players, matchPlayer, position) => {
     distance: bestDistance,
   }
 }
-
-export { mapPlayer }

--- a/src/refresh/teamsheet/map-team.js
+++ b/src/refresh/teamsheet/map-team.js
@@ -18,4 +18,3 @@ export function mapTeam (teams, matchTeam) {
     distance: bestDistance,
   }
 }
-

--- a/src/refresh/teamsheet/map-team.js
+++ b/src/refresh/teamsheet/map-team.js
@@ -1,6 +1,6 @@
 import { calculateDistance } from '../../levenshtein.js'
 
-const mapTeam = (teams, matchTeam) => {
+export function mapTeam (teams, matchTeam) {
   const matchText = matchTeam.replace(/' '/g, '').toUpperCase()
   let bestDistance = -1
   let bestTeamId = -1
@@ -19,4 +19,3 @@ const mapTeam = (teams, matchTeam) => {
   }
 }
 
-export { mapTeam }

--- a/src/refresh/teamsheet/match-team.js
+++ b/src/refresh/teamsheet/match-team.js
@@ -4,14 +4,14 @@ import { mapPosition } from '../map-position.js'
 import { addTeamsheetMatch, addPlayer, addKeeper } from './add-team.js'
 import { getLeagueTeams, getLeaguePlayers } from './get-league-data.js'
 
-const matchTeam = async (managerId, players) => {
+export async function matchTeam (managerId, players) {
   for (const player of players) {
     const position = mapPosition(player.position)
     await matchPlayers(player, position, managerId)
   }
 }
 
-const matchPlayers = async (player, position, managerId) => {
+async function matchPlayers (player, position, managerId) {
   const leagueTeams = await getLeagueTeams()
   const leaguePlayers = await getLeaguePlayers()
 
@@ -26,8 +26,6 @@ const matchPlayers = async (player, position, managerId) => {
   }
 }
 
-const isKeeper = (position) => {
+function isKeeper (position) {
   return position === 'Goalkeeper'
 }
-
-export { matchTeam }

--- a/src/refresh/teamsheet/refresh-teamsheet.js
+++ b/src/refresh/teamsheet/refresh-teamsheet.js
@@ -2,7 +2,7 @@ import { getManager } from './get-league-data.js'
 import { deleteCurrentTeam } from './delete-team.js'
 import { matchTeam } from './match-team.js'
 
-const refresh = async (teams) => {
+export async function refreshTeamsheet (teams) {
   for (const team of teams) {
     const manager = await getManager(team.manager)
     if (manager) {
@@ -14,9 +14,7 @@ const refresh = async (teams) => {
   }
 }
 
-const updateTeam = async (managerId, players) => {
+async function updateTeam (managerId, players) {
   await deleteCurrentTeam(managerId)
   await matchTeam(managerId, players)
 }
-
-export { refresh }

--- a/src/results/create-summary.js
+++ b/src/results/create-summary.js
@@ -5,12 +5,12 @@ import { getTable } from './get-table.js'
 import { getWinners } from './get-winners.js'
 import { getGroups } from './get-groups.js'
 
-const createSummary = async (gameweekId) => {
+export async function createSummary (gameweekId) {
   const summary = await getSummary(gameweekId)
   await db.Summary.upsert({ gameweekId, summary })
 }
 
-const getSummary = async (gameweekId) => {
+async function getSummary (gameweekId) {
   const managers = await db.Manager.findAll()
   const scores = await getScores(gameweekId, managers)
   const winners = getWinners(scores)
@@ -28,4 +28,3 @@ const getSummary = async (gameweekId) => {
   }
 }
 
-export { createSummary }

--- a/src/results/create-summary.js
+++ b/src/results/create-summary.js
@@ -27,4 +27,3 @@ async function getSummary (gameweekId) {
     groups,
   }
 }
-

--- a/src/results/delete-results.js
+++ b/src/results/delete-results.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const deleteResults = async (gameweekId) => {
+export async function deleteResults (gameweekId) {
   const transaction = await db.sequelize.transaction()
   try {
     await db.Concede.destroy({ where: { gameweekId }, transaction })
@@ -12,5 +12,3 @@ const deleteResults = async (gameweekId) => {
     throw error
   }
 }
-
-export { deleteResults }

--- a/src/results/get-all-winners.js
+++ b/src/results/get-all-winners.js
@@ -1,7 +1,7 @@
 import db from '../data/index.js'
 import { getSummary } from './get-summary.js'
 
-const getAllWinners = async () => {
+export async function getAllWinners () {
   const gameweeks = await db.Gameweek.findAll({ include: { model: db.Summary, as: 'summary', attributes: [], required: true } })
   const winners = []
   for (const gameweek of gameweeks) {
@@ -12,5 +12,3 @@ const getAllWinners = async () => {
   }
   return winners
 }
-
-export { getAllWinners }

--- a/src/results/get-cup-scores.js
+++ b/src/results/get-cup-scores.js
@@ -1,7 +1,7 @@
 import db from '../data/index.js'
 import { getScores } from './get-scores.js'
 
-const getCupScores = async (gameweekId, managers) => {
+export async function getCupScores (gameweekId, managers) {
   const cupScores = []
   const scores = await getScores(gameweekId, managers, true)
 
@@ -35,7 +35,7 @@ const getCupScores = async (gameweekId, managers) => {
   return cupScores
 }
 
-const getCupResult = (homeMargin, awayMargin) => {
+function getCupResult (homeMargin, awayMargin) {
   if (homeMargin > awayMargin) {
     return 'H'
   }
@@ -44,5 +44,3 @@ const getCupResult = (homeMargin, awayMargin) => {
   }
   return 'D'
 }
-
-export { getCupScores }

--- a/src/results/get-cup-weeks.js
+++ b/src/results/get-cup-weeks.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const getCupWeeks = async () => {
+export async function getCupWeeks () {
   const managers = await db.Manager.findAll()
   const fixtures = await db.Fixture.findAll()
   const managerCupWeeks = []
@@ -16,4 +16,3 @@ const getCupWeeks = async () => {
   return managerCupWeeks
 }
 
-export { getCupWeeks }

--- a/src/results/get-cup-weeks.js
+++ b/src/results/get-cup-weeks.js
@@ -15,4 +15,3 @@ export async function getCupWeeks () {
 
   return managerCupWeeks
 }
-

--- a/src/results/get-gameweek-results.js
+++ b/src/results/get-gameweek-results.js
@@ -3,7 +3,7 @@ import { getConceded, getGoals } from './get-goals.js'
 import { getPoints } from './get-points.js'
 import { getResult } from './get-result.js'
 
-const getGameweekResults = async (gameweekId, managerId) => {
+export async function getGameweekResults (gameweekId, managerId) {
   const gameweeks = await db.Gameweek.findAll({ where: { gameweekId: { [db.Sequelize.Op.lte]: gameweekId } } })
   const gameweekResults = []
   for (const gameweek of gameweeks) {
@@ -16,4 +16,3 @@ const getGameweekResults = async (gameweekId, managerId) => {
   return gameweekResults
 }
 
-export { getGameweekResults }

--- a/src/results/get-gameweek-results.js
+++ b/src/results/get-gameweek-results.js
@@ -15,4 +15,3 @@ export async function getGameweekResults (gameweekId, managerId) {
   }
   return gameweekResults
 }
-

--- a/src/results/get-goals.js
+++ b/src/results/get-goals.js
@@ -1,11 +1,9 @@
 import db from '../data/index.js'
 
-const getGoals = async (gameweekId, managerId, cup = false) => {
+export async function getGoals (gameweekId, managerId, cup = false) {
   return db.Goal.findAll({ where: { managerId, gameweekId, cup } })
 }
 
-const getConceded = async (gameweekId, managerId, cup = false) => {
+export async function getConceded (gameweekId, managerId, cup = false) {
   return db.Concede.findAll({ where: { managerId, gameweekId, cup } })
 }
-
-export { getGoals, getConceded }

--- a/src/results/get-groups.js
+++ b/src/results/get-groups.js
@@ -2,7 +2,7 @@ import db from '../data/index.js'
 import { getCupScores } from './get-cup-scores.js'
 import { orderTable } from './order-table.js'
 
-const getGroups = async (gameweekId) => {
+export async function getGroups (gameweekId) {
   const cups = await db.Cup.findAll({ where: { hasGroupStage: true } })
 
   const groupTables = []
@@ -71,4 +71,3 @@ const getGroups = async (gameweekId) => {
   return groupTables
 }
 
-export { getGroups }

--- a/src/results/get-groups.js
+++ b/src/results/get-groups.js
@@ -70,4 +70,3 @@ export async function getGroups (gameweekId) {
   }
   return groupTables
 }
-

--- a/src/results/get-input.js
+++ b/src/results/get-input.js
@@ -3,12 +3,10 @@ import { getKeepers } from './get-keepers.js'
 import { getPlayers } from './get-players.js'
 import { getCupWeeks } from './get-cup-weeks.js'
 
-const getInput = async () => {
+export async function getInput () {
   const gameweeks = await db.Gameweek.findAll()
   const cupWeeks = await getCupWeeks()
   const keepers = await getKeepers()
   const players = await getPlayers()
   return { gameweeks, cupWeeks, keepers, players }
 }
-
-export { getInput }

--- a/src/results/get-keepers.js
+++ b/src/results/get-keepers.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const getKeepers = async () => {
+export async function getKeepers () {
   return db.ManagerKeeper.findAll({
     where: { substitute: false },
     include: [{ model: db.Team, attributes: [], include: { model: db.Division, as: 'division', attributes: [] } }, {
@@ -11,4 +11,3 @@ const getKeepers = async () => {
   })
 }
 
-export { getKeepers }

--- a/src/results/get-keepers.js
+++ b/src/results/get-keepers.js
@@ -10,4 +10,3 @@ export async function getKeepers () {
     raw: true,
   })
 }
-

--- a/src/results/get-players.js
+++ b/src/results/get-players.js
@@ -13,4 +13,3 @@ export async function getPlayers () {
     attributes: ['managerId', 'playerId', [db.Sequelize.col('Player.firstName'), 'firstName'], [db.Sequelize.col('Player.lastName'), 'lastName'], [db.Sequelize.col('Player.team.name'), 'team'], [db.Sequelize.col('Player.team.division.name'), 'division'], [db.Sequelize.col('Player.team.division.shortName'), 'divisionShortName'], [db.Sequelize.col('Manager.name'), 'manager']],
   })
 }
-

--- a/src/results/get-players.js
+++ b/src/results/get-players.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const getPlayers = async () => {
+export async function getPlayers () {
   return db.ManagerPlayer.findAll({
     where: { substitute: false },
     include: [{
@@ -14,4 +14,3 @@ const getPlayers = async () => {
   })
 }
 
-export { getPlayers }

--- a/src/results/get-points.js
+++ b/src/results/get-points.js
@@ -1,6 +1,6 @@
 import { W, D } from '../constants/results.js'
 
-const getPoints = (result) => {
+export function getPoints (result) {
   switch (result) {
     case W:
       return 3
@@ -10,5 +10,3 @@ const getPoints = (result) => {
       return 0
   }
 }
-
-export { getPoints }

--- a/src/results/get-result.js
+++ b/src/results/get-result.js
@@ -1,6 +1,6 @@
 import { W, D, L } from '../constants/results.js'
 
-const getResult = (goals, conceded) => {
+export function getResult (goals, conceded) {
   if (goals > conceded) {
     return W
   }
@@ -9,5 +9,3 @@ const getResult = (goals, conceded) => {
   }
   return D
 }
-
-export { getResult }

--- a/src/results/get-scores.js
+++ b/src/results/get-scores.js
@@ -2,7 +2,7 @@ import db from '../data/index.js'
 import { getConceded, getGoals } from './get-goals.js'
 import { getResult } from './get-result.js'
 
-const getScores = async (gameweekId, managers, cup = false) => {
+export async function getScores (gameweekId, managers, cup = false) {
   const scores = []
   for (const manager of managers) {
     const goals = await getGoals(gameweekId, manager.managerId, cup)
@@ -23,7 +23,7 @@ const getScores = async (gameweekId, managers, cup = false) => {
   return scores
 }
 
-const getScorers = async (goals) => {
+async function getScorers (goals) {
   const scorers = []
   goals.reduce((x, y) => {
     if (!x[y.playerId]) {
@@ -39,5 +39,3 @@ const getScorers = async (goals) => {
   }
   return scorers
 }
-
-export { getScores }

--- a/src/results/get-summary.js
+++ b/src/results/get-summary.js
@@ -1,11 +1,9 @@
 import db from '../data/index.js'
 
-const getSummary = async (gameweekId = 0) => {
+export async function getSummary (gameweekId = 0) {
   if (gameweekId === 0) {
     gameweekId = await db.Summary.max('gameweekId') ?? 0
   }
   const summary = await db.Summary.findOne({ where: { gameweekId }, raw: true }) ?? {}
   return summary.summary
 }
-
-export { getSummary }

--- a/src/results/get-table.js
+++ b/src/results/get-table.js
@@ -28,4 +28,3 @@ export async function getTable (gameweekId, managers) {
   }
   return orderTable(rows)
 }
-

--- a/src/results/get-table.js
+++ b/src/results/get-table.js
@@ -2,7 +2,7 @@ import { getGameweekResults } from './get-gameweek-results.js'
 import { orderTable } from './order-table.js'
 import { W, D, L } from '../constants/results.js'
 
-const getTable = async (gameweekId, managers) => {
+export async function getTable (gameweekId, managers) {
   const rows = []
   for (const manager of managers) {
     const gameweekResults = await getGameweekResults(gameweekId, manager.managerId)
@@ -29,4 +29,3 @@ const getTable = async (gameweekId, managers) => {
   return orderTable(rows)
 }
 
-export { getTable }

--- a/src/results/get-winners.js
+++ b/src/results/get-winners.js
@@ -1,6 +1,4 @@
-const getWinners = (scores) => {
+export function getWinners (scores) {
   const winningMargin = Math.max.apply(Math, scores.map(x => { return x.margin }))
   return scores.filter(x => x.margin === winningMargin).map(x => { return { managerId: x.managerId, manager: x.manager, goals: x.goals } })
 }
-
-export { getWinners }

--- a/src/results/index.js
+++ b/src/results/index.js
@@ -1,5 +1,0 @@
-export { getSummary } from './get-summary.js'
-export { getInput } from './get-input.js'
-export { update } from './update.js'
-export { deleteResults } from './delete-results.js'
-export { getAllWinners } from './get-all-winners.js'

--- a/src/results/order-table.js
+++ b/src/results/order-table.js
@@ -1,8 +1,6 @@
 import { sortArray } from '../utils/sort-array.js'
 
-const orderTable = (rows) => {
+export function orderTable (rows) {
   return rows.sort((a, b) => { return sortArray(b.points, a.points) || sortArray(b.gd, a.gd) || sortArray(b.gf, a.gf) || sortArray(a.manager, b.manager) })
     .map((x, i) => ({ position: i + 1, ...x }))
 }
-
-export { orderTable }

--- a/src/results/update.js
+++ b/src/results/update.js
@@ -1,7 +1,7 @@
 import db from '../data/index.js'
 import { createSummary } from './create-summary.js'
 
-const update = async (results) => {
+export async function update (results) {
   const resultsDate = new Date()
   await updateConceded(results, resultsDate)
   await updateGoals(results, resultsDate)
@@ -10,7 +10,7 @@ const update = async (results) => {
   await createSummary(results.gameweekId)
 }
 
-const updateConceded = async (results, resultsDate) => {
+async function updateConceded (results, resultsDate) {
   const conceded = results.conceded?.filter(x => x.conceded > 0) || []
   for (const concede of conceded) {
     const manager = await db.ManagerKeeper.findOne({ where: { teamId: concede.teamId } })
@@ -29,7 +29,7 @@ const updateConceded = async (results, resultsDate) => {
   }
 }
 
-const updateGoals = async (results, resultsDate) => {
+async function updateGoals (results, resultsDate) {
   const goals = results.goals?.filter(x => x.goals > 0) || []
   for (const goal of goals) {
     const manager = await db.ManagerPlayer.findOne({ where: { playerId: goal.playerId } })
@@ -48,7 +48,7 @@ const updateGoals = async (results, resultsDate) => {
   }
 }
 
-const updateConcededCup = async (results, resultsDate) => {
+async function updateConcededCup (results, resultsDate) {
   const conceded = results.concededCup?.filter(x => x.conceded > 0) || []
   for (const concede of conceded) {
     const manager = await db.ManagerKeeper.findOne({ where: { teamId: concede.teamId } })
@@ -67,7 +67,7 @@ const updateConcededCup = async (results, resultsDate) => {
   }
 }
 
-const updateGoalsCup = async (results, resultsDate) => {
+async function updateGoalsCup (results, resultsDate) {
   const goals = results.goalsCup?.filter(x => x.goals > 0) || []
   for (const goal of goals) {
     const manager = await db.ManagerPlayer.findOne({ where: { playerId: goal.playerId } })
@@ -85,5 +85,3 @@ const updateGoalsCup = async (results, resultsDate) => {
     }
   }
 }
-
-export { update }

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -1,1 +1,0 @@
-export { search } from './search.js'

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const search = async (prefix) => {
+export async function search (prefix) {
   const result = []
 
   // Search players
@@ -119,5 +119,3 @@ const search = async (prefix) => {
 
   return result
 }
-
-export { search }

--- a/src/server/create-server.js
+++ b/src/server/create-server.js
@@ -8,7 +8,7 @@ import errors from './plugins/errors.js'
 import router from './plugins/router.js'
 import logging from './plugins/logging.js'
 
-const createServer = async () => {
+export async function createServer () {
   const server = Hapi.server({
     port: config.port,
     routes: {
@@ -35,5 +35,3 @@ const createServer = async () => {
 
   return server
 }
-
-export { createServer }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,1 +1,0 @@
-export { start } from './start.js'

--- a/src/server/plugins/auth.js
+++ b/src/server/plugins/auth.js
@@ -1,5 +1,5 @@
 import config from '../../config/index.js'
-import { validate } from '../../token/index.js'
+import { validate } from '../../token/validate.js'
 
 export default {
   plugin: {

--- a/src/server/routes/conceded.js
+++ b/src/server/routes/conceded.js
@@ -3,7 +3,7 @@ import boom from '@hapi/boom'
 import db from '../../data/index.js'
 import { GET, POST } from '../../constants/verbs.js'
 import { OK } from '../../constants/ok.js'
-import { update } from '../../results/index.js'
+import { update } from '../../results/update.js'
 
 export default [{
   method: GET,

--- a/src/server/routes/goals.js
+++ b/src/server/routes/goals.js
@@ -3,7 +3,7 @@ import boom from '@hapi/boom'
 import db from '../../data/index.js'
 import { GET, POST } from '../../constants/verbs.js'
 import { OK } from '../../constants/ok.js'
-import { update } from '../../results/index.js'
+import { update } from '../../results/update.js'
 
 export default [{
   method: GET,

--- a/src/server/routes/identity/forgot-password.js
+++ b/src/server/routes/identity/forgot-password.js
@@ -1,6 +1,6 @@
 import boom from '@hapi/boom'
 import Joi from 'joi'
-import { resetPassword } from '../../../account/index.js'
+import { resetPassword } from '../../../account/reset-password.js'
 import { POST } from '../../../constants/verbs.js'
 import { OK } from '../../../constants/ok.js'
 

--- a/src/server/routes/identity/login.js
+++ b/src/server/routes/identity/login.js
@@ -1,6 +1,6 @@
 import boom from '@hapi/boom'
 import Joi from 'joi'
-import { login } from '../../../account/index.js'
+import { login } from '../../../account/login.js'
 import { POST } from '../../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/identity/register.js
+++ b/src/server/routes/identity/register.js
@@ -1,6 +1,6 @@
 import boom from '@hapi/boom'
 import Joi from 'joi'
-import { register } from '../../../account/index.js'
+import { register } from '../../../account/register.js'
 import { POST } from '../../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/identity/reset-password.js
+++ b/src/server/routes/identity/reset-password.js
@@ -1,6 +1,6 @@
 import boom from '@hapi/boom'
 import Joi from 'joi'
-import { setNewPassword } from '../../../account/index.js'
+import { setNewPassword } from '../../../account/reset-password.js'
 import { POST } from '../../../constants/verbs.js'
 import { OK } from '../../../constants/ok.js'
 

--- a/src/server/routes/league/player.js
+++ b/src/server/routes/league/player.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
 import db from '../../../data/index.js'
-import { refresh } from '../../../refresh/players/index.js'
+import { refreshPlayers } from '../../../refresh/players/refresh-players.js'
 import { GET, POST } from '../../../constants/verbs.js'
 import { GOALKEEPER, DEFENDER, MIDFIELDER, FORWARD } from '../../../constants/positions.js'
 
@@ -168,7 +168,7 @@ export default [{
       },
     },
     handler: async (request, h) => {
-      return h.response(await refresh(request.payload.players))
+      return h.response(await refreshPlayers(request.payload.players))
     },
   },
 }]

--- a/src/server/routes/managers.js
+++ b/src/server/routes/managers.js
@@ -1,8 +1,13 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
 import db from '../../data/index.js'
-import { getManager, getManagers, createManager, editManager, deleteManager, getTeam } from '../../managers/index.js'
-import { getSummary } from '../../results/index.js'
+import { getManagers } from '../../managers/get-managers.js'
+import { getManager } from '../../managers/get-manager.js'
+import { createManager } from '../../managers/create-manager.js'
+import { editManager } from '../../managers/edit-manager.js'
+import { deleteManager } from '../../managers/delete-manager.js'
+import { getTeam } from '../../managers/get-team.js'
+import { getSummary } from '../../results/get-summary.js'
 import { GET, POST } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/results.js
+++ b/src/server/routes/results.js
@@ -1,7 +1,10 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
-import { getSummary, getInput, update, deleteResults } from '../../results/index.js'
-import { sendResults } from '../../notifications/index.js'
+import { getSummary } from '../../results/get-summary.js'
+import { getInput } from '../../results/get-input.js'
+import { update } from '../../results/update.js'
+import { deleteResults } from '../../results/delete-results.js'
+import { sendResults } from '../../notifications/send-results.js'
 import { GET, POST, DELETE } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
-import { search } from '../../search/index.js'
+import { search } from '../../search/search.js'
 import { POST } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/statistics.js
+++ b/src/server/routes/statistics.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
-import { getForm, getTopScorers } from '../../statistics/index.js'
+import { getForm } from '../../statistics/get-form.js'
+import { getTopScorers } from '../../statistics/get-top-scorers.js'
 import { GET } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/teamsheet.js
+++ b/src/server/routes/teamsheet.js
@@ -1,7 +1,9 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
-import { getTeamsheet, updatePlayer, updateKeeper } from '../../teamsheet/index.js'
-import { refreshTeamsheet } from '../../refresh/index.js'
+import { getTeamsheet } from '../../teamsheet/get-teamsheet.js'
+import { updatePlayer } from '../../teamsheet/update-player.js'
+import { updateKeeper } from '../../teamsheet/update-keeper.js'
+import { refreshTeamsheet } from '../../refresh/teamsheet/refresh-teamsheet.js'
 import { GET, POST } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/validate.js
+++ b/src/server/routes/validate.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import boom from '@hapi/boom'
-import { validate } from '../../token/index.js'
+import { validate } from '../../token/validate.js'
 import { POST } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/routes/winners.js
+++ b/src/server/routes/winners.js
@@ -1,4 +1,4 @@
-import { getAllWinners } from '../../results/index.js'
+import { getAllWinners } from '../../results/get-all-winners.js'
 import { GET } from '../../constants/verbs.js'
 
 export default [{

--- a/src/server/start.js
+++ b/src/server/start.js
@@ -1,8 +1,6 @@
 import { createServer } from './create-server.js'
 
-const start = async () => {
+export async function start () {
   const server = await createServer()
   await server.start()
 }
-
-export { start }

--- a/src/statistics/get-form.js
+++ b/src/statistics/get-form.js
@@ -2,7 +2,7 @@ import db from '../data/index.js'
 import { getPoints } from '../results/get-points.js'
 import { sortArray } from '../utils/sort-array.js'
 
-const getForm = async (weeksToInclude = 6) => {
+export async function getForm (weeksToInclude = 6) {
   const managers = await db.Manager.findAll({ raw: true })
   let summaries = await db.Summary.findAll({ raw: true, order: [['gameweekId', 'DESC']], limit: weeksToInclude })
   summaries = summaries.reverse()
@@ -25,9 +25,7 @@ const getForm = async (weeksToInclude = 6) => {
   return orderForm(form)
 }
 
-const orderForm = (form) => {
+function orderForm (form) {
   return form.sort((a, b) => { return sortArray(b.points, a.points) || sortArray(a.manager, b.manager) })
     .map((x, i) => ({ position: i + 1, ...x }))
 }
-
-export { getForm }

--- a/src/statistics/get-top-scorers.js
+++ b/src/statistics/get-top-scorers.js
@@ -1,7 +1,7 @@
 import db from '../data/index.js'
 import { sortArray } from '../utils/sort-array.js'
 
-const getTopScorers = async () => {
+export async function getTopScorers () {
   const playersToInclude = await db.Manager.count()
   let goals = await db.Goal.findAll({
     raw: true,
@@ -33,9 +33,7 @@ const getTopScorers = async () => {
   return orderScorers(scorers)
 }
 
-const orderScorers = (scorers) => {
+function orderScorers (scorers) {
   return scorers.sort((a, b) => { return sortArray(b.goals, a.goals) || sortArray(a.lastName, b.lastName) || sortArray(a.firstName, b.firstName) })
     .map((x, i) => ({ position: i + 1, ...x }))
 }
-
-export { getTopScorers }

--- a/src/statistics/index.js
+++ b/src/statistics/index.js
@@ -1,2 +1,0 @@
-export { getForm } from './get-form.js'
-export { getTopScorers } from './get-top-scorers.js'

--- a/src/teamsheet/get-teamsheet.js
+++ b/src/teamsheet/get-teamsheet.js
@@ -1,7 +1,7 @@
 import db from '../data/index.js'
 import { mapTeams } from './map-teams.js'
 
-const getTeamsheet = async () => {
+export async function getTeamsheet () {
   const managers = await db.Manager.findAll({
     include: [
       {
@@ -20,5 +20,3 @@ const getTeamsheet = async () => {
 
   return managers.map(x => mapTeams(x.dataValues))
 }
-
-export { getTeamsheet }

--- a/src/teamsheet/index.js
+++ b/src/teamsheet/index.js
@@ -1,3 +1,0 @@
-export { getTeamsheet } from './get-teamsheet.js'
-export { update as updatePlayer } from './update-player.js'
-export { update as updateKeeper } from './update-keeper.js'

--- a/src/teamsheet/map-keeper.js
+++ b/src/teamsheet/map-keeper.js
@@ -1,4 +1,4 @@
-const mapKeeper = (keeper, teamsheet) => {
+export function mapKeeper (keeper, teamsheet) {
   const teamsheetEntry = teamsheet.find(x => x.bestMatchId === keeper.teamId && x.position === 'Goalkeeper')
   return {
     playerId: keeper.teamId,
@@ -9,5 +9,3 @@ const mapKeeper = (keeper, teamsheet) => {
     substitute: keeper.managerKeepers.dataValues.substitute,
   }
 }
-
-export { mapKeeper }

--- a/src/teamsheet/map-player.js
+++ b/src/teamsheet/map-player.js
@@ -12,4 +12,3 @@ export function mapPlayer (player, teamsheet) {
     substitute: player.managerPlayers.dataValues.substitute,
   }
 }
-

--- a/src/teamsheet/map-player.js
+++ b/src/teamsheet/map-player.js
@@ -1,4 +1,4 @@
-const mapPlayer = (player, teamsheet) => {
+export function mapPlayer (player, teamsheet) {
   const teamsheetEntry = teamsheet.find(x => x.dataValues.bestMatchId === player.dataValues.playerId && x.dataValues.position === player.dataValues.position)
   return {
     playerId: player.dataValues.playerId,
@@ -13,4 +13,3 @@ const mapPlayer = (player, teamsheet) => {
   }
 }
 
-export { mapPlayer }

--- a/src/teamsheet/map-teams.js
+++ b/src/teamsheet/map-teams.js
@@ -3,7 +3,7 @@ import { mapKeeper } from './map-keeper.js'
 import { orderKeepers } from '../utils/order-keepers.js'
 import { orderPlayers } from '../utils/order-players.js'
 
-const mapTeams = (team) => {
+export function mapTeams (team) {
   return {
     managerId: team.managerId,
     name: team.name,
@@ -11,5 +11,3 @@ const mapTeams = (team) => {
     players: orderPlayers(team.players.map(x => mapPlayer(x, team.teamsheet))),
   }
 }
-
-export { mapTeams }

--- a/src/teamsheet/update-keeper.js
+++ b/src/teamsheet/update-keeper.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const update = async (payload) => {
+export async function updateKeeper (payload) {
   const manager = await getManager(payload.managerId)
   await updateTeams(payload.teamIds, manager)
   await updateSubs(payload.teamSubs, payload.managerId)
@@ -9,7 +9,7 @@ const update = async (payload) => {
   }
 }
 
-const updateSubs = async (teamSubs, managerId) => {
+async function updateSubs (teamSubs, managerId) {
   const selectedSubIds = getSelectedSubIds(teamSubs)
   const currentSubs = await getCurrentSubs(managerId)
 
@@ -17,7 +17,7 @@ const updateSubs = async (teamSubs, managerId) => {
   await addNewSubs(selectedSubIds, currentSubs, managerId)
 }
 
-const updateTeams = async (teamIds, manager) => {
+async function updateTeams (teamIds, manager) {
   const selectedTeamIds = getSelectedTeamIds(teamIds)
   const currentTeamIds = getCurrentTeamIds(manager.dataValues.keepers)
 
@@ -25,7 +25,7 @@ const updateTeams = async (teamIds, manager) => {
   await addNewKeepers(selectedTeamIds, currentTeamIds, manager.managerId)
 }
 
-const addNewSubs = async (selectedSubIds, currentSubs, managerId) => {
+async function addNewSubs (selectedSubIds, currentSubs, managerId) {
   for (const selectedSubId of selectedSubIds) {
     if (!currentSubs.includes(selectedSubId)) {
       const managerKeeper = await db.ManagerKeeper.findOne({ where: { managerId, teamId: selectedSubId } })
@@ -35,7 +35,7 @@ const addNewSubs = async (selectedSubIds, currentSubs, managerId) => {
   }
 }
 
-const deleteOldSubs = async (currentSubs, selectedSubIds) => {
+async function deleteOldSubs (currentSubs, selectedSubIds) {
   for (const currentSub of currentSubs) {
     if (!selectedSubIds.includes(currentSub.teamId)) {
       currentSub.substitute = false
@@ -44,16 +44,16 @@ const deleteOldSubs = async (currentSubs, selectedSubIds) => {
   }
 }
 
-const getCurrentSubs = async (managerId) => {
+async function getCurrentSubs (managerId) {
   return db.ManagerKeeper.findAll({ where: { managerId, substitute: true } })
 }
 
-const getSelectedSubIds = (teamSubs) => {
+function getSelectedSubIds (teamSubs) {
   teamSubs = Array.isArray(teamSubs) ? teamSubs : [teamSubs]
   return teamSubs.filter(x => x !== 0 && x !== undefined)
 }
 
-const addNewKeepers = async (selectedTeamIds, currentTeamIds, managerId) => {
+async function addNewKeepers (selectedTeamIds, currentTeamIds, managerId) {
   for (const selectedTeam of selectedTeamIds) {
     if (!currentTeamIds.includes(selectedTeam)) {
       await db.ManagerKeeper.create({ managerId, teamId: selectedTeam, substitute: false })
@@ -61,7 +61,7 @@ const addNewKeepers = async (selectedTeamIds, currentTeamIds, managerId) => {
   }
 }
 
-const deleteOldKeepers = async (currentTeamIds, selectedTeamIds, managerId) => {
+async function deleteOldKeepers (currentTeamIds, selectedTeamIds, managerId) {
   for (const currentTeamId of currentTeamIds) {
     const currentCount = currentTeamIds.filter(x => x.teamId === currentTeamId).length
     const selectedCount = selectedTeamIds.filter(x => x === currentTeamId).length
@@ -73,16 +73,16 @@ const deleteOldKeepers = async (currentTeamIds, selectedTeamIds, managerId) => {
   }
 }
 
-const getCurrentTeamIds = (teams) => {
+function getCurrentTeamIds (teams) {
   return teams.map(x => x.teamId)
 }
 
-const getSelectedTeamIds = (teamIds) => {
+function getSelectedTeamIds (teamIds) {
   teamIds = Array.isArray(teamIds) ? teamIds : [teamIds]
   return teamIds.filter(x => x !== 0 && x !== undefined)
 }
 
-const getManager = async (managerId) => {
+async function getManager (managerId) {
   return db.Manager.findOne({
     where: { managerId },
     include: [
@@ -96,5 +96,3 @@ const getManager = async (managerId) => {
     nest: true,
   })
 }
-
-export { update }

--- a/src/teamsheet/update-player.js
+++ b/src/teamsheet/update-player.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const update = async (payload) => {
+export async function updatePlayer (payload) {
   const manager = await getManager(payload.managerId)
   await updatePlayers(payload.playerIds, manager)
   await updateSubs(payload.playerSubs, payload.managerId)
@@ -9,7 +9,7 @@ const update = async (payload) => {
   }
 }
 
-const updateSubs = async (playerSubs, managerId) => {
+async function updateSubs (playerSubs, managerId) {
   const selectedSubIds = getSelectedSubIds(playerSubs)
   const currentSubs = await getCurrentSubs(managerId)
 
@@ -17,7 +17,7 @@ const updateSubs = async (playerSubs, managerId) => {
   await addNewSubs(selectedSubIds, currentSubs, managerId)
 }
 
-const updatePlayers = async (playerIds, manager) => {
+async function updatePlayers (playerIds, manager) {
   const selectedPlayerIds = getSelectedPlayerIds(playerIds)
   const currentPlayerIds = getCurrentPlayerIds(manager.dataValues.players)
 
@@ -25,7 +25,7 @@ const updatePlayers = async (playerIds, manager) => {
   await addNewPlayers(selectedPlayerIds, currentPlayerIds, manager.managerId)
 }
 
-const addNewSubs = async (selectedSubIds, currentSubs, managerId) => {
+async function addNewSubs (selectedSubIds, currentSubs, managerId) {
   for (const selectedSubId of selectedSubIds) {
     if (!currentSubs.includes(selectedSubId)) {
       const managerPlayer = await db.ManagerPlayer.findOne({ where: { managerId, playerId: selectedSubId } })
@@ -35,7 +35,7 @@ const addNewSubs = async (selectedSubIds, currentSubs, managerId) => {
   }
 }
 
-const deleteOldSubs = async (currentSubs, selectedSubIds) => {
+async function deleteOldSubs (currentSubs, selectedSubIds) {
   for (const currentSub of currentSubs) {
     if (!selectedSubIds.includes(currentSub.playerId)) {
       currentSub.substitute = false
@@ -44,16 +44,16 @@ const deleteOldSubs = async (currentSubs, selectedSubIds) => {
   }
 }
 
-const getCurrentSubs = async (managerId) => {
+async function getCurrentSubs (managerId) {
   return db.ManagerPlayer.findAll({ where: { managerId, substitute: true } })
 }
 
-const getSelectedSubIds = (playerSubs) => {
+function getSelectedSubIds (playerSubs) {
   playerSubs = Array.isArray(playerSubs) ? playerSubs : [playerSubs]
   return playerSubs.filter(x => x !== 0 && x !== undefined)
 }
 
-const addNewPlayers = async (selectedPlayerIds, currentPlayerIds, managerId) => {
+async function addNewPlayers (selectedPlayerIds, currentPlayerIds, managerId) {
   for (const selectedPlayerId of selectedPlayerIds) {
     if (!currentPlayerIds.includes(selectedPlayerId)) {
       await db.ManagerPlayer.create({ managerId, playerId: selectedPlayerId, substitute: false })
@@ -61,7 +61,7 @@ const addNewPlayers = async (selectedPlayerIds, currentPlayerIds, managerId) => 
   }
 }
 
-const deleteOldPlayers = async (currentPlayerIds, selectedPlayerIds, managerId) => {
+async function deleteOldPlayers (currentPlayerIds, selectedPlayerIds, managerId) {
   for (const currentPlayerId of currentPlayerIds) {
     const currentCount = currentPlayerIds.filter(x => x.playerId === currentPlayerId).length
     const selectedCount = selectedPlayerIds.filter(x => x === currentPlayerId).length
@@ -73,16 +73,16 @@ const deleteOldPlayers = async (currentPlayerIds, selectedPlayerIds, managerId) 
   }
 }
 
-const getCurrentPlayerIds = (players) => {
+function getCurrentPlayerIds (players) {
   return players.map(x => x.playerId)
 }
 
-const getSelectedPlayerIds = (playerIds) => {
+function getSelectedPlayerIds (playerIds) {
   playerIds = Array.isArray(playerIds) ? playerIds : [playerIds]
   return playerIds.filter(x => x !== 0 && x !== undefined)
 }
 
-const getManager = async (managerId) => {
+async function getManager (managerId) {
   return db.Manager.findOne({
     where: { managerId },
     include: [
@@ -97,5 +97,3 @@ const getManager = async (managerId) => {
     nest: true,
   })
 }
-
-export { update }

--- a/src/token/create.js
+++ b/src/token/create.js
@@ -1,18 +1,16 @@
 import jwt from 'jsonwebtoken'
 import config from '../config/index.js'
 
-const create = (user) => {
+export function create (user) {
   const body = mapUserToBody(user)
   return jwt.sign(body, config.jwtConfig.secret, {
     expiresIn: `${config.jwtConfig.expiryInMinutes}m`,
   })
 }
 
-const mapUserToBody = (user) => {
+function mapUserToBody (user) {
   return {
     userId: user.userId,
     scope: user.roles.map(x => x.Role.name),
   }
 }
-
-export { create }

--- a/src/token/index.js
+++ b/src/token/index.js
@@ -1,2 +1,0 @@
-export { create } from './create.js'
-export { validate } from './validate.js'

--- a/src/token/validate.js
+++ b/src/token/validate.js
@@ -1,6 +1,6 @@
 import db from '../data/index.js'
 
-const validate = async (decoded, _request, _h) => {
+export async function validate (decoded, _request, _h) {
   const user = await db.User.findOne({
     raw: true,
     where: { userId: decoded.userId },
@@ -10,5 +10,3 @@ const validate = async (decoded, _request, _h) => {
   }
   return { isValid: true }
 }
-
-export { validate }

--- a/src/utils/order-keepers.js
+++ b/src/utils/order-keepers.js
@@ -1,7 +1,5 @@
 import { sortArray } from './sort-array.js'
 
-const orderKeepers = (keepers) => {
+export function orderKeepers (keepers) {
   return keepers.sort((a, b) => { return sortArray(a.substitute, b.substitute) || sortArray(a.name, b.name) })
 }
-
-export { orderKeepers }

--- a/src/utils/order-players.js
+++ b/src/utils/order-players.js
@@ -1,8 +1,6 @@
 import { sortArray } from './sort-array.js'
 import { rankPosition } from './rank-position.js'
 
-const orderPlayers = (players) => {
+export function orderPlayers (players) {
   return players.sort((a, b) => { return sortArray(rankPosition(a.position), rankPosition(b.position)) || sortArray(a.substitute, b.substitute) || sortArray(a.lastNameFirstName, b.lastNameFirstName) })
 }
-
-export { orderPlayers }

--- a/src/utils/rank-position.js
+++ b/src/utils/rank-position.js
@@ -1,4 +1,4 @@
-const rankPosition = (position) => {
+export function rankPosition (position) {
   switch (position) {
     case 'Defender':
       return 0
@@ -8,5 +8,3 @@ const rankPosition = (position) => {
       return 2
   }
 }
-
-export { rankPosition }

--- a/src/utils/sort-array.js
+++ b/src/utils/sort-array.js
@@ -1,6 +1,4 @@
-const sortArray = (a, b) => {
+export function sortArray (a, b) {
   const order = a < b ? -1 : 1
   return a === b ? 0 : order
 }
-
-export { sortArray }

--- a/test/integration/player-refresh.test.js
+++ b/test/integration/player-refresh.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { refresh } from '../../src/refresh/players/index.js'
+import { refreshPlayers } from '../../src/refresh/players/refresh-players.js'
 import testData from '../data/index.js'
 
 describe('refreshing player list', () => {
@@ -30,7 +30,7 @@ describe('refreshing player list', () => {
       team: 'Wycombe',
     }]
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeTruthy()
   })
@@ -48,7 +48,7 @@ describe('refreshing player list', () => {
       team: 'Wycombe',
     }]
 
-    await refresh(players)
+    await refreshPlayers(players)
     const savedPlayers = await db.Player.findAll()
 
     expect(savedPlayers.filter(x => x.firstName === players[0].firstName && x.lastName === players[0].lastName).length).toBe(1)
@@ -77,7 +77,7 @@ describe('refreshing player list', () => {
       team: 'Wycombe',
     }]
 
-    await refresh(players)
+    await refreshPlayers(players)
     const savedPlayers = await db.Player.findAll()
 
     expect(savedPlayers.filter(x => x.firstName === players[0].firstName && x.lastName === players[0].lastName).length).toBe(1)
@@ -98,7 +98,7 @@ describe('refreshing player list', () => {
       team: 'WycoMbe',
     }]
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeTruthy()
   })
@@ -116,7 +116,7 @@ describe('refreshing player list', () => {
       team: 'Wycomb',
     }]
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeFalsy()
     expect(result.unmappedPlayers.length).toBe(2)
@@ -135,7 +135,7 @@ describe('refreshing player list', () => {
       team: 'Wycomb',
     }]
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeFalsy()
     expect(result.unmappedPlayers.length).toBe(1)
@@ -154,14 +154,14 @@ describe('refreshing player list', () => {
       team: 'Wycomb',
     }]
 
-    await refresh(players)
+    await refreshPlayers(players)
 
     const { count } = await db.Player.findAndCountAll()
     expect(count).toBe(0)
   })
 
   test('should return failure if position invalid', async () => {
-    const result = await refresh([{
+    const result = await refreshPlayers([{
       firstName: 'Ian',
       lastName: 'Henderson',
       position: 'ST',

--- a/test/integration/results-get-input.test.js
+++ b/test/integration/results-get-input.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { getInput } from '../../src/results/index.js'
+import { getInput } from '../../src/results/get-input.js'
 import testData from '../data/index.js'
 
 describe('get results input', () => {

--- a/test/integration/results-update.test.js
+++ b/test/integration/results-update.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { update } from '../../src/results/index.js'
+import { update } from '../../src/results/update.js'
 import testData from '../data/index.js'
 
 describe('get results input', () => {

--- a/test/integration/statistics-form.test.js
+++ b/test/integration/statistics-form.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { getForm } from '../../src/statistics/index.js'
+import { getForm } from '../../src/statistics/get-form.js'
 import testData from '../data/index.js'
 
 describe('get form', () => {

--- a/test/integration/statistics-top-scorers.test.js
+++ b/test/integration/statistics-top-scorers.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { getTopScorers } from '../../src/statistics/index.js'
+import { getTopScorers } from '../../src/statistics/get-top-scorers.js'
 import testData from '../data/index.js'
 
 describe('get top goalscorers', () => {

--- a/test/integration/teamsheet-refresh.test.js
+++ b/test/integration/teamsheet-refresh.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { refreshTeamsheet } from '../../src/refresh/index.js'
+import { refreshTeamsheet } from '../../src/refresh/teamsheet/refresh-teamsheet.js'
 import testData from '../data/index.js'
 
 describe('refreshing teamsheet', () => {

--- a/test/integration/teamsheet-update.test.js
+++ b/test/integration/teamsheet-update.test.js
@@ -1,5 +1,6 @@
 import db from '../../src/data/index.js'
-import { updatePlayer, updateKeeper } from '../../src/teamsheet/index.js'
+import { updatePlayer } from '../../src/teamsheet/update-player.js'
+import { updateKeeper } from '../../src/teamsheet/update-keeper.js'
 import testData from '../data/index.js'
 
 describe('update teamsheet', () => {

--- a/test/integration/teamsheet.test.js
+++ b/test/integration/teamsheet.test.js
@@ -1,5 +1,5 @@
 import db from '../../src/data/index.js'
-import { getTeamsheet } from '../../src/teamsheet/index.js'
+import { getTeamsheet } from '../../src/teamsheet/get-teamsheet.js'
 import testData from '../data/index.js'
 
 describe('get teamsheet', () => {

--- a/test/unit/account-login.test.js
+++ b/test/unit/account-login.test.js
@@ -12,7 +12,7 @@ vi.mock('bcrypt', () => ({
   default: { compare: mockCompare },
 }))
 
-vi.mock('../../src/token/index.js', () => ({
+vi.mock('../../src/token/create.js', () => ({
   create: mockCreate,
 }))
 

--- a/test/unit/account-register.test.js
+++ b/test/unit/account-register.test.js
@@ -15,7 +15,7 @@ vi.mock('../../src/account/user-manager.js', () => ({
   isMember: mockIsMember,
 }))
 
-vi.mock('../../src/token/index.js', () => ({
+vi.mock('../../src/token/create.js', () => ({
   create: mockCreate,
 }))
 

--- a/test/unit/player-refresh.test.js
+++ b/test/unit/player-refresh.test.js
@@ -13,7 +13,7 @@ vi.mock('../../src/data/index.js', () => ({
   },
 }))
 
-import { refresh } from '../../src/refresh/players/index.js'
+import { refreshPlayers } from '../../src/refresh/players/refresh-players.js'
 
 const players = [{
   firstName: 'Ian',
@@ -35,7 +35,7 @@ describe('refreshing player list unit', () => {
   test('should return success if list valid', async () => {
     db.Team.findOne.mockResolvedValue(1)
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeTruthy()
   })
@@ -43,7 +43,7 @@ describe('refreshing player list unit', () => {
   test('should return failure if all teams invalid', async () => {
     db.Team.findOne.mockResolvedValue(null)
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeFalsy()
     expect(result.unmappedPlayers.length).toBe(2)
@@ -53,7 +53,7 @@ describe('refreshing player list unit', () => {
     db.Team.findOne.mockResolvedValue(null)
       .mockResolvedValueOnce(1)
 
-    const result = await refresh(players)
+    const result = await refreshPlayers(players)
 
     expect(result.success).toBeFalsy()
     expect(result.unmappedPlayers.length).toBe(1)
@@ -63,7 +63,7 @@ describe('refreshing player list unit', () => {
     db.Team.findOne.mockResolvedValue(null)
       .mockResolvedValueOnce(1)
 
-    await refresh(players)
+    await refreshPlayers(players)
 
     expect(db.Player.truncate.mock.calls.length).toBe(0)
     expect(db.Player.bulkCreate.mock.calls.length).toBe(0)
@@ -72,7 +72,7 @@ describe('refreshing player list unit', () => {
   test('should return failure if position invalid', async () => {
     db.Team.findOne.mockResolvedValue(null)
 
-    const result = await refresh([{
+    const result = await refreshPlayers([{
       firstName: 'Ian',
       lastName: 'Henderson',
       position: 'ST',


### PR DESCRIPTION
## Summary
- Convert all top-level `const` arrow function declarations to proper `function` declarations with inline `export` keywords
- Remove all 11 pure barrel `index.js` files and update consumers to import directly from source modules
- Rename ambiguous exports for clarity: `update` → `updatePlayer`/`updateKeeper`, `refresh` → `refreshPlayers`/`refreshTeamsheet`
- Rename logic-containing `index.js` files to descriptive names (`refresh-players.js`, `refresh-teamsheet.js`)

## Test plan
- [x] All 33 test files pass (208 tests)
- [x] No remaining references to deleted barrel modules
- [x] All arrow function conversions preserve original behavior (function declarations are hoisted, no `this` usage)