### PR TITLE
Address Sonar issues

### DIFF
--- a/src/managers/edit-manager.ts
+++ b/src/managers/edit-manager.ts
@@ -11,7 +11,7 @@ export async function editManager (manager: any) {
     }
   }
   for (const currentEmail of currentEmails) {
-    if (!manager.emails.some((x: any) => x === (currentEmail as any).address)) {
+    if (!manager.emails.includes((currentEmail as any).address)) {
       await db.Email.destroy({ where: { emailId: (currentEmail as any).emailId } })
     }
   }

--- a/src/results/get-groups.ts
+++ b/src/results/get-groups.ts
@@ -3,6 +3,29 @@ import db from '../data/index.ts'
 import { getCupScores } from './get-cup-scores.ts'
 import { orderTable } from './order-table.ts'
 
+function calculateManagerStats (manager: any, scores: any[]) {
+  const managerScores = scores.filter(x => x.homeManagerId === manager.managerId || x.awayManagerId === manager.managerId)
+  const homeWon = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'H').length
+  const awayWon = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'A').length
+  const won = homeWon + awayWon
+  const homeDrawn = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'D').length
+  const awayDrawn = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'D').length
+  const drawn = homeDrawn + awayDrawn
+  const homeLost = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'A').length
+  const awayLost = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'H').length
+  const lost = homeLost + awayLost
+  const homeGF = managerScores.filter(x => x.homeManagerId === manager.managerId).reduce((x, y) => x + y.homeMargin, 0)
+  const awayGF = managerScores.filter(x => x.awayManagerId === manager.managerId).reduce((x, y) => x + y.awayMargin, 0)
+  const gf = homeGF + awayGF
+  const homeGA = managerScores.filter(x => x.homeManagerId === manager.managerId).reduce((x, y) => x + y.awayMargin, 0)
+  const awayGA = managerScores.filter(x => x.awayManagerId === manager.managerId).reduce((x, y) => x + y.homeMargin, 0)
+  const ga = homeGA + awayGA
+  const gd = gf - ga
+  const points = (won * 3) + drawn
+  const played = won + drawn + lost
+  return { managerId: manager.managerId, manager: manager.name, played, won, drawn, lost, gf, ga, gd, points }
+}
+
 export async function getGroups (gameweekId: number): Promise<any[]> {
   const cups = await db.Cup.findAll({ where: { hasGroupStage: true } })
 
@@ -27,42 +50,9 @@ export async function getGroups (gameweekId: number): Promise<any[]> {
         const scores: any[] = []
         for (const gameweek of gameweekIds) {
           const cupScores = await getCupScores(gameweek, group.managers)
-          Array.prototype.push.apply(scores, cupScores)
+          scores.push(...cupScores)
         }
-        let table = []
-        for (const manager of group.managers) {
-          const managerScores = scores.filter(x => x.homeManagerId === manager.managerId || x.awayManagerId === manager.managerId)
-          const homeWon = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'H').length
-          const awayWon = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'A').length
-          const won = homeWon + awayWon
-          const homeDrawn = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'D').length
-          const awayDrawn = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'D').length
-          const drawn = homeDrawn + awayDrawn
-          const homeLost = managerScores.filter(x => x.homeManagerId === manager.managerId && x.result === 'A').length
-          const awayLost = managerScores.filter(x => x.awayManagerId === manager.managerId && x.result === 'H').length
-          const lost = homeLost + awayLost
-          const homeGF = managerScores.filter(x => x.homeManagerId === manager.managerId).reduce((x, y) => x + y.homeMargin, 0)
-          const awayGF = managerScores.filter(x => x.awayManagerId === manager.managerId).reduce((x, y) => x + y.awayMargin, 0)
-          const gf = homeGF + awayGF
-          const homeGA = managerScores.filter(x => x.homeManagerId === manager.managerId).reduce((x, y) => x + y.awayMargin, 0)
-          const awayGA = managerScores.filter(x => x.awayManagerId === manager.managerId).reduce((x, y) => x + y.homeMargin, 0)
-          const ga = homeGA + awayGA
-          const gd = gf - ga
-          const points = (won * 3) + drawn
-          const played = won + drawn + lost
-          table.push({
-            managerId: manager.managerId,
-            manager: manager.name,
-            played,
-            won,
-            drawn,
-            lost,
-            gf,
-            ga,
-            gd,
-            points,
-          })
-        }
+        let table = group.managers.map((manager: any) => calculateManagerStats(manager, scores))
         table = orderTable(table)
         groupTables.push(table)
       }

--- a/src/results/get-winners.ts
+++ b/src/results/get-winners.ts
@@ -1,4 +1,4 @@
 export function getWinners (scores: any[]): any[] {
-  const winningMargin = Math.max.apply(Math, scores.map(x => { return x.margin }))
-  return scores.filter(x => x.margin === winningMargin).map(x => { return { managerId: x.managerId, manager: x.manager, goals: x.goals } })
+  const winningMargin = Math.max(...scores.map(x => x.margin))
+  return scores.filter(x => x.margin === winningMargin).map(x => ({ managerId: x.managerId, manager: x.manager, goals: x.goals }))
 }


### PR DESCRIPTION
## Summary
- Extract `calculateManagerStats` helper to reduce cognitive complexity in `get-groups.ts` (S3776)
- Use spread operator instead of `.apply()` in `get-winners.ts` (S6666)
- Use `.includes()` instead of `.some()` for simple value check in `edit-manager.ts` (S7765)

## Not fixed (false positives / won't fix)
- **S8215** (bcrypt hash in `login.ts`) — This is a dummy hash for constant-time comparison to prevent user enumeration. Not a real credential.
- **S5976** (parameterize tests) — Tests are clearer in their current form with distinct setup per case.

## Test plan
- [x] All 251 tests pass