### PR TITLE
Enhance player upload

### DIFF
--- a/src/refresh/players/confirm-players.ts
+++ b/src/refresh/players/confirm-players.ts
@@ -1,0 +1,11 @@
+import { run } from './run.ts'
+
+export async function confirmPlayers (players: any[]) {
+  const invalid = players.filter((p: any) => !p.teamId || !p.position)
+  if (invalid.length) {
+    return { success: false, message: 'All players must have a teamId and position' }
+  }
+
+  await run(players)
+  return { success: true }
+}

--- a/src/refresh/players/preview-players.ts
+++ b/src/refresh/players/preview-players.ts
@@ -1,0 +1,33 @@
+import { mapPlayer } from './map-player.ts'
+
+interface UnmappedTeam {
+  team: string
+  players: Array<{ firstName: string; lastName: string; position: string }>
+}
+
+export async function previewPlayers (players: any[]) {
+  const mappedPlayers = []
+  const unmappedByTeam = new Map<string, UnmappedTeam>()
+
+  for (const player of players) {
+    const mappedPlayer = await mapPlayer(player)
+    if (mappedPlayer) {
+      mappedPlayers.push(mappedPlayer)
+    } else {
+      const teamName = player.team || 'Unknown'
+      if (!unmappedByTeam.has(teamName)) {
+        unmappedByTeam.set(teamName, { team: teamName, players: [] })
+      }
+      unmappedByTeam.get(teamName)!.players.push({
+        firstName: player.firstName,
+        lastName: player.lastName,
+        position: player.position,
+      })
+    }
+  }
+
+  return {
+    mappedPlayers,
+    unmappedTeams: [...unmappedByTeam.values()],
+  }
+}

--- a/src/server/routes/league/player.ts
+++ b/src/server/routes/league/player.ts
@@ -4,6 +4,8 @@ import { Op } from 'sequelize'
 import Joi from 'joi'
 import db from '../../../data/index.ts'
 import { refreshPlayers } from '../../../refresh/players/refresh-players.ts'
+import { previewPlayers } from '../../../refresh/players/preview-players.ts'
+import { confirmPlayers } from '../../../refresh/players/confirm-players.ts'
 import { GOALKEEPER, DEFENDER, MIDFIELDER, FORWARD } from '../../../constants/positions.ts'
 
 export default [{
@@ -194,6 +196,46 @@ export default [{
     },
     handler: async (request, h) => {
       return h.response(await refreshPlayers((request.payload as any).players))
+    },
+  },
+}, {
+  method: 'POST',
+  path: '/league/players/refresh/preview',
+  options: {
+    auth: { strategy: 'jwt', scope: ['admin'] },
+    validate: {
+      payload: Joi.object({
+        players: Joi.array().items(Joi.object({
+          firstName: Joi.string().allow('', null),
+          lastName: Joi.string().allow('', null),
+          position: Joi.string().allow('', null),
+          team: Joi.string().allow('', null),
+        })),
+      }),
+      failAction,
+    },
+    handler: async (request, h) => {
+      return h.response(await previewPlayers((request.payload as any).players))
+    },
+  },
+}, {
+  method: 'POST',
+  path: '/league/players/refresh/confirm',
+  options: {
+    auth: { strategy: 'jwt', scope: ['admin'] },
+    validate: {
+      payload: Joi.object({
+        players: Joi.array().items(Joi.object({
+          firstName: Joi.string().allow('', null),
+          lastName: Joi.string().allow('', null),
+          position: Joi.string().required(),
+          teamId: Joi.number().integer().required(),
+        })),
+      }),
+      failAction,
+    },
+    handler: async (request, h) => {
+      return h.response(await confirmPlayers((request.payload as any).players))
     },
   },
 }] satisfies ServerRoute[]

--- a/test/unit/confirm-players.test.ts
+++ b/test/unit/confirm-players.test.ts
@@ -1,0 +1,67 @@
+import { vi, describe, afterEach, test, expect } from 'vitest'
+
+const { mockPlayer } = vi.hoisted(() => ({
+  mockPlayer: { truncate: vi.fn(), bulkCreate: vi.fn() },
+}))
+
+vi.mock('../../src/data/index.ts', () => ({
+  default: {
+    Player: mockPlayer,
+  },
+}))
+
+import { confirmPlayers } from '../../src/refresh/players/confirm-players.ts'
+
+describe('confirm players', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should truncate and bulk create players', async () => {
+    const players = [{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'Forward',
+      teamId: 1,
+    }]
+
+    const result = await confirmPlayers(players)
+
+    expect(result.success).toBe(true)
+    expect(mockPlayer.truncate).toHaveBeenCalledOnce()
+    expect(mockPlayer.bulkCreate).toHaveBeenCalledWith(players)
+  })
+
+  test('should reject if any player missing teamId', async () => {
+    const players = [{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'Forward',
+      teamId: 1,
+    }, {
+      firstName: 'Joe',
+      lastName: 'Bloggs',
+      position: 'Defender',
+      teamId: undefined,
+    }]
+
+    const result = await confirmPlayers(players)
+
+    expect(result.success).toBe(false)
+    expect(mockPlayer.truncate).not.toHaveBeenCalled()
+  })
+
+  test('should reject if any player missing position', async () => {
+    const players = [{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: '',
+      teamId: 1,
+    }]
+
+    const result = await confirmPlayers(players)
+
+    expect(result.success).toBe(false)
+    expect(mockPlayer.truncate).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/preview-players.test.ts
+++ b/test/unit/preview-players.test.ts
@@ -1,0 +1,96 @@
+import { vi, describe, afterEach, test, expect } from 'vitest'
+
+const { mockTeam } = vi.hoisted(() => ({
+  mockTeam: { findOne: vi.fn() },
+}))
+
+vi.mock('../../src/data/index.ts', () => ({
+  default: {
+    Team: mockTeam,
+    Sequelize: { Op: { iLike: Symbol('iLike') } },
+  },
+}))
+
+import { previewPlayers } from '../../src/refresh/players/preview-players.ts'
+
+const players = [{
+  firstName: 'Ian',
+  lastName: 'Henderson',
+  position: 'FWD',
+  team: 'Rochdale',
+}, {
+  firstName: 'Adebayo',
+  lastName: 'Akinfenwa',
+  position: 'FWD',
+  team: 'Wycombe',
+}, {
+  firstName: 'Joe',
+  lastName: 'Bloggs',
+  position: 'DEF',
+  team: 'Wycombe',
+}]
+
+describe('preview players', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should return all players as mapped when all teams match', async () => {
+    mockTeam.findOne.mockResolvedValue({ teamId: 1 })
+
+    const result = await previewPlayers(players)
+
+    expect(result.mappedPlayers).toHaveLength(3)
+    expect(result.unmappedTeams).toHaveLength(0)
+  })
+
+  test('should group unmapped players by team name', async () => {
+    mockTeam.findOne.mockResolvedValueOnce({ teamId: 1 })
+      .mockResolvedValue(null)
+
+    const result = await previewPlayers(players)
+
+    expect(result.mappedPlayers).toHaveLength(1)
+    expect(result.unmappedTeams).toHaveLength(1)
+    expect(result.unmappedTeams[0]!.team).toBe('Wycombe')
+    expect(result.unmappedTeams[0]!.players).toHaveLength(2)
+  })
+
+  test('should return multiple unmapped team groups', async () => {
+    mockTeam.findOne.mockResolvedValue(null)
+
+    const result = await previewPlayers(players)
+
+    expect(result.mappedPlayers).toHaveLength(0)
+    expect(result.unmappedTeams).toHaveLength(2)
+    expect(result.unmappedTeams[0]!.team).toBe('Rochdale')
+    expect(result.unmappedTeams[1]!.team).toBe('Wycombe')
+  })
+
+  test('should include player details in unmapped teams', async () => {
+    mockTeam.findOne.mockResolvedValue(null)
+
+    const result = await previewPlayers(players)
+
+    const rochdale = result.unmappedTeams.find(t => t.team === 'Rochdale')
+    expect(rochdale!.players[0]).toEqual({
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'FWD',
+    })
+  })
+
+  test('should handle invalid position as unmapped', async () => {
+    mockTeam.findOne.mockResolvedValue({ teamId: 1 })
+
+    const result = await previewPlayers([{
+      firstName: 'Joe',
+      lastName: 'Bloggs',
+      position: 'ST',
+      team: 'Rochdale',
+    }])
+
+    expect(result.mappedPlayers).toHaveLength(0)
+    expect(result.unmappedTeams).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `POST /league/players/refresh/preview` endpoint that returns mapped players and groups unmapped players by team name
- Add `POST /league/players/refresh/confirm` endpoint that accepts the fully resolved player list and commits it
- Instead of rejecting the entire upload when teams don't match, unmapped teams are surfaced for manual resolution

## Test plan
- [x] Unit tests for `previewPlayers` (all-match, partial-match, grouping by team)
- [x] Unit tests for `confirmPlayers` (success, missing teamId rejection)
- [x] All 270 existing tests pass