### PR TITLE
Map position on refresh anomaly

### DIFF
--- a/src/refresh/players/confirm-players.ts
+++ b/src/refresh/players/confirm-players.ts
@@ -1,11 +1,20 @@
 import { run } from './run.ts'
+import { mapPosition } from '../map-position.ts'
+import { GOALKEEPER, DEFENDER, MIDFIELDER, FORWARD } from '../../constants/positions.ts'
+
+const validPositions = new Set([GOALKEEPER, DEFENDER, MIDFIELDER, FORWARD])
 
 export async function confirmPlayers (players: any[]) {
-  const invalid = players.filter((p: any) => !p.teamId || !p.position)
+  const normalised = players.map((p: any) => ({
+    ...p,
+    position: mapPosition(p.position) ?? p.position,
+  }))
+
+  const invalid = normalised.filter((p: any) => !p.teamId || !validPositions.has(p.position))
   if (invalid.length) {
     return { success: false, message: 'All players must have a teamId and position' }
   }
 
-  await run(players)
+  await run(normalised)
   return { success: true }
 }

--- a/src/refresh/players/preview-players.ts
+++ b/src/refresh/players/preview-players.ts
@@ -1,4 +1,5 @@
 import { mapPlayer } from './map-player.ts'
+import { mapPosition } from '../map-position.ts'
 
 interface UnmappedTeam {
   team: string
@@ -21,7 +22,7 @@ export async function previewPlayers (players: any[]) {
       unmappedByTeam.get(teamName)!.players.push({
         firstName: player.firstName,
         lastName: player.lastName,
-        position: player.position,
+        position: mapPosition(player.position) ?? player.position,
       })
     }
   }

--- a/test/unit/confirm-players.test.ts
+++ b/test/unit/confirm-players.test.ts
@@ -64,4 +64,37 @@ describe('confirm players', () => {
     expect(result.success).toBe(false)
     expect(mockPlayer.truncate).not.toHaveBeenCalled()
   })
+
+  test('should normalise position codes before saving', async () => {
+    const players = [{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'MID',
+      teamId: 1,
+    }]
+
+    const result = await confirmPlayers(players)
+
+    expect(result.success).toBe(true)
+    expect(mockPlayer.bulkCreate).toHaveBeenCalledWith([{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'Midfielder',
+      teamId: 1,
+    }])
+  })
+
+  test('should reject invalid position values', async () => {
+    const players = [{
+      firstName: 'Ian',
+      lastName: 'Henderson',
+      position: 'ST',
+      teamId: 1,
+    }]
+
+    const result = await confirmPlayers(players)
+
+    expect(result.success).toBe(false)
+    expect(mockPlayer.truncate).not.toHaveBeenCalled()
+  })
 })

--- a/test/unit/preview-players.test.ts
+++ b/test/unit/preview-players.test.ts
@@ -67,7 +67,7 @@ describe('preview players', () => {
     expect(result.unmappedTeams[1]!.team).toBe('Wycombe')
   })
 
-  test('should include player details in unmapped teams', async () => {
+  test('should include player details in unmapped teams with mapped position', async () => {
     mockTeam.findOne.mockResolvedValue(null)
 
     const result = await previewPlayers(players)
@@ -76,8 +76,39 @@ describe('preview players', () => {
     expect(rochdale!.players[0]).toEqual({
       firstName: 'Ian',
       lastName: 'Henderson',
-      position: 'FWD',
+      position: 'Forward',
     })
+  })
+
+  test('should map all position codes in unmapped team players', async () => {
+    mockTeam.findOne.mockResolvedValue(null)
+
+    const result = await previewPlayers([
+      { firstName: 'A', lastName: 'Keeper', position: 'GK', team: 'TestFC' },
+      { firstName: 'B', lastName: 'Back', position: 'DEF', team: 'TestFC' },
+      { firstName: 'C', lastName: 'Middle', position: 'MID', team: 'TestFC' },
+      { firstName: 'D', lastName: 'Striker', position: 'FWD', team: 'TestFC' },
+    ])
+
+    const team = result.unmappedTeams[0]!
+    expect(team.players[0]!.position).toBe('Goalkeeper')
+    expect(team.players[1]!.position).toBe('Defender')
+    expect(team.players[2]!.position).toBe('Midfielder')
+    expect(team.players[3]!.position).toBe('Forward')
+  })
+
+  test('should preserve raw position if code is unrecognised', async () => {
+    mockTeam.findOne.mockResolvedValue(null)
+
+    const result = await previewPlayers([{
+      firstName: 'Joe',
+      lastName: 'Bloggs',
+      position: 'ST',
+      team: 'Rochdale',
+    }])
+
+    const rochdale = result.unmappedTeams.find(t => t.team === 'Rochdale')
+    expect(rochdale!.players[0]!.position).toBe('ST')
   })
 
   test('should handle invalid position as unmapped', async () => {


### PR DESCRIPTION
## Summary
- Position codes (GK, DEF, MID, FWD) are now normalised to full names (Goalkeeper, Defender, Midfielder, Forward) when players go through the unmapped team review path
- Added defensive normalisation in `confirmPlayers` so position codes are always mapped before database insertion
- Tightened position validation to reject unrecognised values

## Test plan
- [x] Existing tests pass (278/278)
- [x] New test: unmapped team players have position codes mapped to full names
- [x] New test: `confirmPlayers` normalises position codes before saving
- [x] New test: `confirmPlayers` rejects invalid position values (e.g. "ST")
- [x] New test: unrecognised position codes preserved as-is in unmapped preview (so the admin can see what came from the source)